### PR TITLE
Add Chitin: Soul identity for AI agents using EIP-5192 SBTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A curated list of awesome links related to Soulbound Tokens.
 
 ## Implementations
 
-- [Chitin](https://chitin.id) - Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet.
+- [Chitin](https://chitin.id) - Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 - [ERC4973 Account-bound tokens Reference implementation](https://github.com/rugpullindex/ERC4973)
 - [Tribz Soulbound tokens](https://blockscout.com/xdai/mainnet/address/0x2043F330339E21Afe6DC6207500B24AcF74068fC/contracts#address-tabs)
 - [Asshole Soulbound token](https://etherscan.io/address/0x0855B3B667Be89efcF9eE54a79aEcB25a194A8b0#code)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A curated list of awesome links related to Soulbound Tokens.
 
 ## Implementations
 
+- [Chitin](https://chitin.id) - Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet.
 - [ERC4973 Account-bound tokens Reference implementation](https://github.com/rugpullindex/ERC4973)
 - [Tribz Soulbound tokens](https://blockscout.com/xdai/mainnet/address/0x2043F330339E21Afe6DC6207500B24AcF74068fC/contracts#address-tabs)
 - [Asshole Soulbound token](https://etherscan.io/address/0x0855B3B667Be89efcF9eE54a79aEcB25a194A8b0#code)


### PR DESCRIPTION
Adds [Chitin](https://chitin.id) to the Implementations section.

Chitin issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents on Base L2, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet.